### PR TITLE
Python Config Update Script

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -1,0 +1,31 @@
+#Imports
+import configparser
+import platform
+import os
+
+#Config Updating
+if os.path.isfile('config.ini') == False:
+    import shutil
+    shutil.copy('default.ini', 'config.ini')
+
+config = configparser.ConfigParser()
+config.read('config.ini')
+
+if platform.system() == 'Linux':
+    system = 'linux-' #Include dash for distro that is appended to this string
+elif platform.system() == 'Darwin':
+    system = 'darwin'
+elif platform.system() == 'Windows':
+    system = 'windows'
+
+if system == 'linux-':
+    import distro
+    switch = {
+        'debian': 'debian',
+        'ubuntu': 'debian'
+    }
+    system += switch.get(distro.id(), 'error')
+
+config.set('OS', 'platform', system)
+cfgfile = open("config.ini",'w')
+config.write(cfgfile)

--- a/default.ini
+++ b/default.ini
@@ -1,5 +1,5 @@
 [OS]
-platform = darwin
+platform = (Set Platform with configuration.py)
 
 [CACHE]
 keep_cache = True


### PR DESCRIPTION
This script updates the config platform attribute to have a value of darwin, windows, or linux-distro for the values of the operating system for when installing packages